### PR TITLE
feat(toggle): re-add attributes to elements inside a `ngRepeat`.

### DIFF
--- a/src/components/milestone/milestone.html
+++ b/src/components/milestone/milestone.html
@@ -6,6 +6,7 @@
 		flex
 		ed-add-attr="is-expanded"
 		ed-toggle-attr-group="milestones"
+		ed-toggle-attr-id="{{ milestone.number }}"
 		ed-toggle-attr-closest="ed-milestone"
 	>
 		{{ milestone.title | untag }}

--- a/src/components/toggle/toggle.attr.js
+++ b/src/components/toggle/toggle.attr.js
@@ -30,6 +30,36 @@
 		return add;
 	}
 
+	// Group Map Methods
+	function setActiveGroupItem ( groupName, attrName, el, id ) {
+		if ( groupName ) {
+			if ( toggleGroup[groupName] && toggleGroup[groupName].element ) {
+				toggleGroup[groupName].element.removeAttr(attrName);
+			}
+			toggleGroup[groupName] = {
+				element: el,
+				identifier: id
+			};
+		}
+	}
+
+	function removeActiveGroupItem ( groupName, attrName, el ) {
+		if( isDefined(el.attr(attrName)) ) {
+			el.removeAttr(attrName);
+		}
+		if( groupName ) {
+			if ( toggleGroup[groupName] && toggleGroup[groupName].element ) {
+				toggleGroup[groupName].element.removeAttr(attrName);
+			}
+			toggleGroup[groupName] = {};
+		}
+	}
+
+	function wasActive ( groupName, attrName, id ) {
+		return groupName && id && toggleGroup[groupName] && toggleGroup[groupName].identifier === id;
+	}
+
+
 
 	// Toggle
 	// -------------------------
@@ -42,17 +72,20 @@
 	function ToggleDirectiveLink ( scope, element, attr ) {
 		var attrName = attr.edToggleAttr;
 		if( !attrName ) { return; }
-		element.on('click', function () {
+		if ( wasActive( attr.edToggleAttrGroup, attrName, attr.edToggleAttrId ) ) {
+			toggleAttribute();
+		}
+		element.on('click', toggleAttribute );
+
+		function toggleAttribute () {
 			var el = getElement( element, attr ),
 				added = toggle( el, attrName );
-			// Toggle Groups
-			if( attr.edToggleAttrGroup ) {
-				if( toggleGroup[attr.edToggleAttrGroup] && added ) {
-					toggle(toggleGroup[attr.edToggleAttrGroup], attrName);
-				}
-				toggleGroup[attr.edToggleAttrGroup] = added ? el : undefined;
+			if( added ) {
+				setActiveGroupItem( attr.edToggleAttrGroup, attrName, el, attr.edToggleAttrId );
+			} else {
+				removeActiveGroupItem ( attr.edToggleAttrGroup, attrName, el );
 			}
-		});
+		}
 	}
 
 
@@ -67,17 +100,17 @@
 	function AddDirectiveLink ( scope, element, attr ) {
 		var attrName = attr.edAddAttr;
 		if( !attrName ) { return; }
-		element.on('click', function () {
+		if ( wasActive( attr.edToggleAttrGroup, attrName, attr.edToggleAttrId ) ) {
+			addAttribute();
+		}
+		element.on('click', addAttribute);
+
+		function addAttribute () {
 			var el = getElement( element, attr );
 			if( isDefined(el.attr(attrName)) ) { return; }
 			el.attr(attrName, '');
-			if( attr.edToggleAttrGroup ) {
-				if( toggleGroup[attr.edToggleAttrGroup] ) {
-					toggleGroup[attr.edToggleAttrGroup].removeAttr(attrName);
-				}
-				toggleGroup[attr.edToggleAttrGroup] = el;
-			}
-		});
+			setActiveGroupItem( attr.edToggleAttrGroup, attrName, el, attr.edToggleAttrId );
+		}
 	}
 
 
@@ -94,15 +127,7 @@
 		if( !attrName ) { return; }
 		element.on('click', function () {
 			var el = getElement( element, attr );
-			if( isDefined(el.attr(attrName)) ) {
-				el.removeAttr(attrName);
-			}
-			if( attr.edToggleAttrGroup ) {
-				if( toggleGroup[attr.edToggleAttrGroup] ) {
-					toggleGroup[attr.edToggleAttrGroup].removeAttr(attrName);
-				}
-				toggleGroup[attr.edToggleAttrGroup] = undefined;
-			}
+			removeActiveGroupItem ( attr.edToggleAttrGroup, attrName, el );
 		});
 	}
 

--- a/src/components/toggle/toggle.attr.spec.js
+++ b/src/components/toggle/toggle.attr.spec.js
@@ -2,6 +2,7 @@ describe('toggleAttr', function () {
 	var $rootScope, $compile,
 		element, scope;
 
+	// Custom Jasmine Matchers.
 	//TODO: Add this globally.
 	beforeEach(function () {
 		function toHaveAttrMatcher () {
@@ -9,7 +10,7 @@ describe('toggleAttr', function () {
 				compare: function ( element, attrName, attrValue ) {
 					var result = {
 						pass: element.hasAttribute(attrName),
-						message: 'Expected ' + element.outerHTML + 'to have attribute "' + attrName + '".'
+						message: 'Expected ' + element.outerHTML + ' to have attribute "' + attrName + '".'
 					};
 					if( attrValue && result.pass ) {
 						result.pass = element.getAttribute(attrName) === attrValue;
@@ -305,6 +306,66 @@ describe('toggleAttr', function () {
 			clickElement(1);
 			expect(element[0]).not.toHaveAttr('foo');
 			expect(element[1]).not.toHaveAttr('foo');
+		});
+	});
+
+
+	// Toggle by Identifier
+	// -------------------------
+	describe('Toggle by Identifier', function () {
+		beforeEach(function() {
+			scope = $rootScope.$new();
+			scope.items = [{
+				id: 0,
+				name: 'Item #1'
+			}, {
+				id: 1,
+				name: 'Item #2'
+			}];
+			element = angular.element(
+				'<ul>' +
+				'	<li ng-repeat="i in items" ed-add-attr="foo" ed-toggle-attr-group="group" ed-toggle-attr-id="{{:: i.id}}">{{ i.name }}</li>' +
+				'</ul>' +
+				'<ul>' +
+				'	<li ng-repeat="i in items" ed-toggle-attr="foo" ed-toggle-attr-group="tGroup" ed-toggle-attr-id="{{:: i.id}}">{{ i.name }}</li>' +
+				'</ul>'
+			);
+			$compile( element )( scope );
+			scope.$digest();
+		});
+
+		it('should be possible to re-add attribute when `ng-repeat` is redrawn', function() {
+			// "add" directive
+			element.find('li').eq(0).triggerHandler('click');
+			expect(element.eq(0).children()[0]).toHaveAttr('foo');
+
+			scope.items = [];
+			scope.$digest();
+			scope.items = [{
+				id: 0,
+				name: 'Item #1'
+			}, {
+				id: 1,
+				name: 'Item #2'
+			}];
+			scope.$digest();
+			expect(element.eq(0).children()[0]).toHaveAttr('foo');
+
+			// "toggle" directive
+			element.find('li').eq(2).triggerHandler('click');
+			expect(element.eq(1).children()[0]).toHaveAttr('foo');
+
+			scope.items = [];
+			scope.$digest();
+			scope.items = [{
+				id: 0,
+				name: 'Item #1'
+			}, {
+				id: 1,
+				name: 'Item #2'
+			}];
+			scope.$digest();
+			expect(element.eq(1).children()[0]).toHaveAttr('foo');
 		});
 	});
 });


### PR DESCRIPTION
When we refresh an array that is displayed via `ngRepeat` the reference
to the currently active element is lost. We introduce an additional
attribute `ed-toggle-attr-id` to better refernce list items and re-add
the attribute when the `ngRepeat` is redrawn.

Closes #5
